### PR TITLE
forwarding headers downstream

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-from flask import Flask
+from flask import Flask, request as flask_request
 import requests
 import os
 
@@ -16,7 +16,8 @@ def landing_page():
 @app.route("/ip_addr/<path:path>")
 def proxy(path):
 
-    r = requests.get("http://"+path)
+    # using quick hack to include same headers in downstream request
+    r = requests.get("http://"+path, headers=flask_request.headers)
 
     if r.ok:
 


### PR DESCRIPTION
@agmsbush ```while true; do   curl --header "Authorization: Bearer $(gcloud auth print-identity-token)" --header "Cluster: cluster-green" https://cloudrun-vpc-proxy-tjjxnhbjna-uw.a.run.app/ip_addr/10.138.15.208; done``` should route only to green cluster i.e. headers are being forwarded to downstream service